### PR TITLE
NGX-290: sort certbot_stop_services list so monit is stopped before nginx

### DIFF
--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -20,7 +20,7 @@
     - not letsencrypt_cert.stat.exists
     - certbot_stop_services is defined
     - certbot_stop_services | length > 0
-  with_items: "{{ certbot_stop_services | unique }}"
+  with_items: "{{ certbot_stop_services | unique | sort }}"
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"


### PR DESCRIPTION
- The sort filter forces monit to get stopped before nginx.  This prevents monit from restarting nginx while letsencrypt is trying to start the standalone server and generate a certificate.