### PR TITLE
NGX-334: do not provide email when creating account

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,8 @@ certbot_create_command: >-
   --standalone
   --noninteractive
   --agree-tos
-  --email {{ site_email }}
   -d {{ site_domain }}
+  --register-unsafely-without-email
   {% if certbot_test_cert|bool %}--test-cert{% endif %}
 
 certbot_package: certbot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,8 +40,8 @@
       --standalone
       --noninteractive
       --agree-tos
-      --email {{ site_email }}
       -d {{ site_domain ~ "," ~ "www." ~ site_domain }}
+      --register-unsafely-without-email
       {% if certbot_test_cert|bool %}--test-cert{% endif %}
   when:
     - use_letsencrypt is defined


### PR DESCRIPTION
- Omitting the email address will prevent confusing emails from being sent to the customer.  We can safely omit the email notifications because we will be able to detect issues with certbot, or other things and apply fixes on a larger scale.