### PR TITLE
NGX-743: Adjust certbot command

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ certbot_create_command: >-
   --standalone
   --noninteractive
   --agree-tos
+  --cert-name {{ site_domain }}
+  --allow-subset-of-names
   {% if certbot_without_email %}--register-unsafely-without-email{% else %}--email {{ site_email }}{% endif %}
   -d {{ site_domain }}
   {% if certbot_test_cert|bool %}--test-cert{% endif %}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,8 @@
       --standalone
       --noninteractive
       --agree-tos
+      --cert-name {{ site_domain }}
+      --allow-subset-of-names
       {% if certbot_without_email | bool %}--register-unsafely-without-email{% else %}--email {{ site_email }}{% endif %}
       -d {{ site_domain ~ "," ~ "www." ~ site_domain }}
       {% if certbot_test_cert|bool %}--test-cert{% endif %}


### PR DESCRIPTION
- In some cases the playbook will try and generate a certificate without www. and then again later with www.  This was failing because the initial certificate did not include the www. version of the domain.  To allow certbot to issue a new certificate with a different set of domains we can use the --cert-name flag.  The certbot docs recommend using --cert-name and explicitly defining the domains over the --expand argument.  We can also use --allow-subset-of-names to have the certificate generation succeed if any of the domains are able to have a certificate generated.