### PR TITLE
NGX-763: Retry dns lookup on SERVFAIL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # requirements.txt
 
 ansible-lint
-ansible>=6,<7
+ansible
 dnspython
 molecule-plugins[docker]
-molecule>=5,<6
+molecule
 pre-commit

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
   changed_when: dns_ip not in host_ips
   register: dns_check
   vars:
-    dns_ip: "{{ lookup('dig', site_domain) }}"
+    dns_ip: "{{ lookup('dig', site_domain, retry_servfail=true) }}"
     host_ips: "{{ ansible_all_ipv4_addresses }}"
   when:
     - use_letsencrypt is defined


### PR DESCRIPTION
There have been a few edge cases where DNS lookups fail, and this may be enough to resolve the issue.