### PR TITLE
NGX-825: tag cert tasks with profile

### DIFF
--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -47,7 +47,7 @@
     - certbot_stop_services
 
 - name: Issue certificate or set use_letsencrypt=false
-  tags: siteurl
+  tags: siteurl, profile
   block:
     - name: Generate new certificate if one doesn't exist.
       ansible.builtin.command: "{{ certbot_create_command }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Include variables and set facts
   ansible.builtin.include_tasks: facts.yml
-  tags: siteurl
+  tags: siteurl, profile
 
 - name: Install Let's Encrypt dependent packages
   ansible.builtin.package:
@@ -20,4 +20,4 @@
   when:
     - use_letsencrypt is defined
     - use_letsencrypt
-  tags: siteurl
+  tags: siteurl, profile


### PR DESCRIPTION
When changing the nginx profile, the playbook needs to determine if there is an ssl certificate and set the use_letsencrypt variable appropriately.