### PR TITLE
NGX-817: Handle site_domain when starting with www.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ certbot_create_command: >-
   --cert-name {{ site_domain }}
   --allow-subset-of-names
   {% if certbot_without_email %}--register-unsafely-without-email{% else %}--email {{ site_email }}{% endif %}
-  -d {{ site_domain }}{% if not site_domain.startswith('www') %},www.{{ site_domain }}{% endif %}
+  -d {{ site_domain }}{% if not site_domain.startswith('www') %},www.{{ site_domain }}{% else %}{{ site_domain[4:] }}{% endif %}
   {% if certbot_test_cert | bool %}--test-cert{% endif %}
   --pre-hook /etc/letsencrypt/renewal-hooks/pre/stop_services
   --post-hook /etc/letsencrypt/renewal-hooks/post/start_services


### PR DESCRIPTION
The expected behavior when a server is configured for either www.domain.com or domain.com is that an SSL and the appropriate service configs should be present for both www.domain.com and domain.com.  This commit ensures that is the outcome.